### PR TITLE
Add optional binary rainfall output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # gen-rain
-deep generative models for rainfall generation
+Deep generative models for rainfall generation.
+
+The `GaussianRainfieldGenerator` can now return either binary occurrence
+masks or rainfall amounts depending on the `occurrence_only` flag in
+`sample_precip` and `make_dataset`.


### PR DESCRIPTION
## Summary
- allow generating just rainfall occurrence or occurrence plus intensity
- update PyTorch dataset helper with the same option
- mention new functionality in README

## Testing
- `python -m py_compile data.py`

------
https://chatgpt.com/codex/tasks/task_e_68454be280888321b33d05f44cbb1a82