### PR TITLE
Add correlated rainfall intensities

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,8 @@ Deep generative models for rainfall generation.
 The `GaussianRainfieldGenerator` can now return either binary occurrence
 masks or rainfall amounts depending on the `occurrence_only` flag in
 `sample_precip` and `make_dataset`.
+
+Rainfall intensities may optionally be drawn from a correlated log-normal
+field by setting ``correlated_intensity=True`` when constructing the
+generator.  This uses a second Gaussian process to sample log-rainfall,
+providing spatially coherent amounts on wet pixels.


### PR DESCRIPTION
## Summary
- allow GaussianRainfieldGenerator to optionally draw intensities from a correlated log-normal field
- document new feature in README
- remove unused numpy import

## Testing
- `python - <<'PY'
from data import GaussianRainfieldGenerator

# Without correlation
# (fails: ModuleNotFoundError: No module named 'torch')
PY`

------
https://chatgpt.com/codex/tasks/task_e_6846d9ea13a883218227ab5675a2045a