### PR TITLE
Add optional binary-only rainfall prediction

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ The `GaussianRainfieldGenerator` can now return either binary occurrence
 masks or rainfall amounts depending on the `occurrence_only` flag in
 `sample_precip` and `make_dataset`.
 
+Training and sampling pipelines in `models.py` accept the same option.
+When ``occurrence_only=True`` only the discrete wet/dry diffusion is used,
+allowing lightweight models that predict rainfall occurrence without
+intensity values.
+
 Rainfall intensities may optionally be drawn from a correlated log-normal
 field by setting ``correlated_intensity=True`` when constructing the
 generator.  This uses a second Gaussian process to sample log-rainfall,

--- a/tests/test_occurrence.py
+++ b/tests/test_occurrence.py
@@ -1,0 +1,20 @@
+import os, sys
+import torch
+from torch.utils.data import DataLoader
+
+# Add repository root to path for imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from data import GaussianRainfieldGenerator
+from models import JointRainDiffuser, train, sample
+
+
+def test_occurrence_only_pipeline():
+    gen = GaussianRainfieldGenerator(grid_height=32, grid_width=32)
+    ds = gen.make_dataset(n_samples=4, occurrence_only=True)
+    loader = DataLoader(ds, batch_size=2)
+    model = JointRainDiffuser(T=2, device='cpu')
+    train(model, loader, epochs=1, device='cpu', occurrence_only=True)
+    out = sample(model, n=1, occurrence_only=True)
+    assert out.shape == (1, 1, 32, 32)
+    assert out.max() <= 1 and out.min() >= 0


### PR DESCRIPTION
## Summary
- extend `JointRainDiffuser` forward pass to optionally skip the intensity branch
- add `occurrence_only` option for training and sampling
- document new training/sampling flag in README
- add test covering the occurrence-only pipeline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68481b340d048321a2b32732d81bc379